### PR TITLE
Code fallbacks should all be monospaced

### DIFF
--- a/public/themes/default/css/style.css
+++ b/public/themes/default/css/style.css
@@ -170,7 +170,7 @@ pre code {
   padding: .5em;
   color: #000;
   background: #f8f8ff;
-  font-family: Inconsolata,Monaco,Verdana,Sans-serif;
+  font-family: Inconsolata,Monaco,"Lucida Console",monospace;
   font-size: 13px;
   line-height: 23px;
   margin: 0;

--- a/public/themes/simple/css/style.css
+++ b/public/themes/simple/css/style.css
@@ -176,7 +176,7 @@ pre code {
   padding: .5em;
   color: #000;
   background: #f8f8ff;
-  font-family: Inconsolata,Monaco,Verdana,Sans-serif;
+  font-family: Inconsolata,Monaco,"Lucida Console",monospace;
   font-size: 13px;
   line-height: 23px;
   margin: 0;


### PR DESCRIPTION
Windows machines, by default, do not have Inconsolata or Monaco, which means Verdana is used...non-monospaced fonts + code = suck.
