### PR TITLE
Post tags for the default theme

### DIFF
--- a/public/themes/default/css/style.css
+++ b/public/themes/default/css/style.css
@@ -73,6 +73,20 @@ p {
   color: #666;
 }
 
+ul.tags {
+  list-style-type: none;
+  margin: 0 0 10px 0;
+  padding: 0;
+}
+
+ul.tags li {
+  display: inline-block;
+  padding: 3px 5px;
+  background: #efefef;
+  border-radius: 5px;
+  font-size: 12px;
+}
+
 .container {
   margin: 0 auto;
   width: 600px;

--- a/public/themes/default/inc/tags.blade.php
+++ b/public/themes/default/inc/tags.blade.php
@@ -1,0 +1,7 @@
+<ul class="tags">
+  @foreach ($post->tags as $item)
+    @if ($item->tag != "")
+      <li><a href="{{ url('/tag/'.$item->tag) }}">{{ $item->tag }}</a></li>
+    @endif
+  @endforeach
+</ul>

--- a/public/themes/default/post.blade.php
+++ b/public/themes/default/post.blade.php
@@ -8,6 +8,8 @@
   <section>
     <h2 class="title">{{ $post->title }}</h2>
     {{ md($post->content) }}
+    
+    @include(theme_path('inc.tags'))
   </section>
 @stop
 


### PR DESCRIPTION
The default theme of the current release is missing the post tags at the bottom, not sure if it was intentional or not but it'll be useful to have them there just like other themes :)
![wardrobe tags](https://f.cloud.github.com/assets/191763/673356/d2a2bf0e-d8b4-11e2-9120-b23c5d3666ae.png)
