### PR TITLE
Fixed slashes issue during installation.

### DIFF
--- a/app/controllers/InstallController.php
+++ b/app/controllers/InstallController.php
@@ -129,7 +129,7 @@ class InstallController extends BaseController {
     $path = app_path().'/config/wardrobe.php';
     $content = str_replace(
       array('##title##', '##theme##', "'##per_page##'", "'##installed##'"),
-      array($title, $theme, (int) $per_page, 'true'),
+      array(addslashes($title), $theme, (int) $per_page, 'true'),
       File::get($path)
     );
     return File::put($path, $content);


### PR DESCRIPTION
I installed a blog with the name "Adam's Blog", and it created an error in the /app/config/wardrobe.php like this: 

```
/*
|--------------------------------------------------------------------------
| Site Title
|--------------------------------------------------------------------------
|
| Set this to your sites title
|
*/
'title' => 'Adam's Blog',
```

My merged changes will run addshlashes() to the $title variable when executing the str_replace on this file during installation.
