### PR TITLE
Change 404 messages for a not found blog entry

### DIFF
--- a/app/controllers/PostController.php
+++ b/app/controllers/PostController.php
@@ -63,7 +63,7 @@ class PostController extends BaseController {
 
 		if ( ! $post)
 		{
-			return App::abort(404, 'Page not found');
+			return App::abort(404, 'Post not found');
 		}
 
 		return View::make('themes.'.$this->theme.'.post', compact('post'));

--- a/app/start/global.php
+++ b/app/start/global.php
@@ -52,6 +52,11 @@ App::error(function(Exception $exception, $code)
 	Log::error($exception);
 });
 
+App::missing(function($exception)
+{
+	return Response::view('themes.'.Config::get('wardrope.theme').'.404' array(), 404);
+});
+
 /*
 |--------------------------------------------------------------------------
 | Maintenance Mode Handler


### PR DESCRIPTION
Changed "page not found" to "post not found".
I think this a bit more specific and easier to understand.
Cheers.
