### PR TITLE
Forbidd access to all Theme .blade.php files via .htaccess

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,4 +1,11 @@
 Options +FollowSymLinks
+
+<FilesMatch "*\.blade.php$">
+   Order Deny,Allow
+   Deny from all
+</FilesMatch>
+
+
 RewriteEngine On
 
 RewriteCond %{REQUEST_FILENAME} !-d


### PR DESCRIPTION
This closes a critical security breach.
Without that somebody could go to `example.com/themes/theme_name/post.blade.php` and see it' s complete content in plain text.
