### PR TITLE
Update post link in the simple themes archive.blade.php

### DIFF
--- a/public/themes/simple/archive.blade.php
+++ b/public/themes/simple/archive.blade.php
@@ -15,7 +15,7 @@
     <ul class="archive">
       @foreach ($posts as $post)
         <li>
-          <span>{{ date("M d, Y", strtotime($post->publish_date)) }}</span> <strong><a href="/post/{{ $post->slug }}">{{ $post->title }}</a></strong>
+          <span>{{ date("M d, Y", strtotime($post->publish_date)) }}</span> <strong><a href="{{ url('/post/' . $post->slug) }}">{{ $post->title }}</a></strong>
         </li>
       @endforeach
     </ul>


### PR DESCRIPTION
Update post link in the simple themes archive.blade.php, the current link href value to use the url() helper class as if it was currently set to /post and on sub folders alike and during local testing it failed so updated
