### PR TITLE
Force lowercase emails for Gravatar to work

### DIFF
--- a/app/controllers/api/UserController.php
+++ b/app/controllers/api/UserController.php
@@ -49,7 +49,7 @@ class ApiUserController extends BaseController {
 		$messages = $this->users->validForCreation(
 			Input::get('first_name'),
 			Input::get('last_name'),
-			Str::lower(Input::get('email')),
+			Input::get('email'),
 			Input::get('password')
 		);
 
@@ -61,7 +61,7 @@ class ApiUserController extends BaseController {
 		return $this->users->create(
 			Input::get('first_name'),
 			Input::get('last_name'),
-			Str::lower(Input::get('email')),
+			Input::get('email'),
 			(bool) Input::get('active'),
 			Input::get('password')
 		);
@@ -101,7 +101,7 @@ class ApiUserController extends BaseController {
 			$id,
 			Input::get('first_name'),
 			Input::get('last_name'),
-			Str::lower(Input::get('email')),
+			Input::get('email'),
 			Input::get('password')
 		);
 
@@ -114,7 +114,7 @@ class ApiUserController extends BaseController {
 			$id,
 			Input::get('first_name'),
 			Input::get('last_name'),
-			Str::lower(Input::get('email')),
+			Input::get('email'),
 			(bool) Input::get('active'),
 			Input::get('password')
 		);

--- a/app/controllers/api/UserController.php
+++ b/app/controllers/api/UserController.php
@@ -49,7 +49,7 @@ class ApiUserController extends BaseController {
 		$messages = $this->users->validForCreation(
 			Input::get('first_name'),
 			Input::get('last_name'),
-			Input::get('email'),
+			Str::lower(Input::get('email')),
 			Input::get('password')
 		);
 
@@ -61,7 +61,7 @@ class ApiUserController extends BaseController {
 		return $this->users->create(
 			Input::get('first_name'),
 			Input::get('last_name'),
-			Input::get('email'),
+			Str::lower(Input::get('email')),
 			(bool) Input::get('active'),
 			Input::get('password')
 		);
@@ -101,7 +101,7 @@ class ApiUserController extends BaseController {
 			$id,
 			Input::get('first_name'),
 			Input::get('last_name'),
-			Input::get('email'),
+			Str::lower(Input::get('email')),
 			Input::get('password')
 		);
 
@@ -114,7 +114,7 @@ class ApiUserController extends BaseController {
 			$id,
 			Input::get('first_name'),
 			Input::get('last_name'),
-			Input::get('email'),
+			Str::lower(Input::get('email')),
 			(bool) Input::get('active'),
 			Input::get('password')
 		);

--- a/public/admin/js/app.js
+++ b/public/admin/js/app.js
@@ -238,7 +238,7 @@ $.fn.avatar = function(email, size) {
   if (size == null) {
     size = 28;
   }
-  return $(this).attr("src", '//www.gravatar.com/avatar/' + md5(email) + '?s=' + (size * 2));
+  return $(this).attr("src", '//www.gravatar.com/avatar/' + md5(email.toLowerCase()) + '?s=' + (size * 2));
 };
 
 


### PR DESCRIPTION
Gravatar emails are always lowercase, and yet for some reason is still case sensitive. Any mixed or upper-case email addresses won't get a result and instead display the default Gravatar logo.

The quickest way to fix this is probably to lower the emails on save/update, which is what this pull request does.
